### PR TITLE
fix config file name and add  sample config file

### DIFF
--- a/website/docs/docker.md
+++ b/website/docs/docker.md
@@ -34,5 +34,41 @@ The image uses the repository configuration file by default.
 [Bind mount](https://docs.docker.com/storage/bind-mounts/) a custom file to configure the server:
 
 ```sh
-docker run -d --name=skyhook -v "$(pwd)"/config/server.yml:/app/server.yml -p 6379:6379 skyhook
+docker run -d --name=skyhook -v "$(pwd)"/config/skyhook.yml:/app/skyhook.yml -p 6379:6379 skyhook
 ```
+
+
+If you are running Aerospike in another Docker container, consider changing hostList to `host.docker.internal:3000` as shown in the following exmaple config file (`skyhook.yml`):
+
+
+```
+---
+# Skyhook server configuration
+
+# hostList: localhost:3000
+hostList: host.docker.internal:3000
+namespace: test
+set: redis
+bin: b
+redisPort: 6379
+
+# Aerospike Java Client [com.aerospike.client.policy.ClientPolicy] configuration.
+#clientPolicy:
+#  user: admin
+#  password: pwd@1234
+#  clusterName: cluster1
+#  authMode: EXTERNAL_INSECURE
+#  timeout: 1500
+#  loginTimeout: 3000
+#  asyncMinConnsPerNode: 50
+#  asyncMaxConnsPerNode: 200
+#  failIfNotConnected: true
+#  useServicesAlternate: true
+
+# Bind on unix socket.
+#unixSocket: "/tmp/skyhook.sock"
+
+workerThreads: 2
+bossThreads: 1
+```
+


### PR DESCRIPTION
I found that the config file needs to be named `skyhook.yml` instead of `server.yml`.

I also included a sample config file that helped me to run this locally with Aerospike in a second Docker container.